### PR TITLE
Remove replayio/cypress install from action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -39,8 +39,6 @@ runs:
       id: metadata-file
       run: echo "::set-output name=TMP_FILE::$(mktemp)"
       shell: bash
-    - run: npm i --legacy-peer-deps @replayio/cypress@">=0.2.0"
-      shell: sh
     - run: ${{ inputs.command }} --browser "${{ inputs.browser }}"
       shell: sh
       working-directory: ${{ inputs.working-directory }}


### PR DESCRIPTION
We don't need to install this because the dependency has to be installed already to be configured and it's breaking yarn so let's drop it.